### PR TITLE
WL-3765 Switch from tomcat class to commons-codec

### DIFF
--- a/dav/pom.xml
+++ b/dav/pom.xml
@@ -37,6 +37,10 @@
             <groupId>org.sakaiproject</groupId>
             <artifactId>sakai-dav-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
         <!-- in tomcat common, so no need to bundle -->
 <!--
         <dependency>

--- a/dav/src/java/org/sakaiproject/dav/DavServlet.java
+++ b/dav/src/java/org/sakaiproject/dav/DavServlet.java
@@ -117,7 +117,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.catalina.util.DOMWriter;
-import org.apache.catalina.util.MD5Encoder;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.catalina.util.RequestUtil;
 import org.apache.catalina.util.XMLWriter;
 import org.apache.commons.logging.Log;
@@ -3209,7 +3209,7 @@ public class DavServlet extends HttpServlet
 			String lockTokenStr = req.getServletPath() + "-" + lock.type + "-" + lock.scope + "-" + req.getUserPrincipal() + "-"
 					+ lock.depth + "-" + lock.owner + "-" + lock.tokens + "-" + lock.expiresAt + "-" + System.currentTimeMillis()
 					+ "-" + secret;
-			lockToken = MD5Encoder.encode(md5Helper.digest(lockTokenStr.getBytes()));
+			lockToken = Hex.encodeHexString(md5Helper.digest(lockTokenStr.getBytes()));
 
 			if ((exists) && (object instanceof DirContext) && (lock.depth == INFINITY))
 			{


### PR DESCRIPTION
It has happened before now that tomcat has moved it’s MD5encoder so it’s simpler to just use the one from common-codec as that won’t change and we’re already including it in Sakai.
